### PR TITLE
Move pose update back to RobotStateEstimator

### DIFF
--- a/src/main/java/com/team1816/frc2020/RobotState.java
+++ b/src/main/java/com/team1816/frc2020/RobotState.java
@@ -362,10 +362,6 @@ public class RobotState {
         return Optional.of(params);
     }
 
-    public Pose2d getRobot() {
-        return new Pose2d();
-    }
-
     public synchronized Pose2d getVisionTargetToGoalOffset() {
         // if (SuperstructureCommands.isInCargoShipPosition() && EndEffector.getInstance().getObservedGamePiece() == GamePiece.BALL) {
         //     return Pose2d.fromTranslation(new Translation2d(-6.0, 0.0));

--- a/src/main/java/com/team1816/lib/auto/actions/DriveTrajectory.java
+++ b/src/main/java/com/team1816/lib/auto/actions/DriveTrajectory.java
@@ -53,7 +53,6 @@ public class DriveTrajectory implements Action {
             var pose = mTrajectory.getState().state().getPose();
             mDrive.setHeading(pose.getRotation());
             mRobotState.reset(Timer.getFPGATimestamp(), pose);
-            mDrive.resetPose(pose);
         }
         mDrive.setTrajectory(mTrajectory);
     }


### PR DESCRIPTION
When we integrated 1323's pose management algo, we moved it into Drivetrain creating many issues with resetting the pose and creating a cluttered Drive class. This PR moves it back into RobotStateEstimator and uses the InterpolatingTreeMaps. Both "tried and true" and alternate are there and the algorithms are the same. **However, this code does NEED testing before merging.**